### PR TITLE
fix on setCaret for android devices

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -81,17 +81,11 @@
                     if (el.is(':focus')) {
                         var range, ctrl = el.get(0);
 
-                        // Firefox, WebKit, etc..
-                        if (ctrl.setSelectionRange) {
-                            ctrl.focus();
-                            ctrl.setSelectionRange(pos, pos);
-                        } else { // IE
-                            range = ctrl.createTextRange();
-                            range.collapse(true);
-                            range.moveEnd('character', pos);
-                            range.moveStart('character', pos);
-                            range.select();
-                        }
+                        range = ctrl.createTextRange();
+                        range.collapse(true);
+                        range.moveEnd('character', pos);
+                        range.moveStart('character', pos);
+                        range.select();
                     }
                 } catch (e) {}
             },


### PR DESCRIPTION
I tried to recover the old (v1.13.9) function "setCaret" in order to get rid of the caret positioning problem on android devices. I tested this modification on my Samsung Galaxy Note3 8" running Android 4.4.2 (KitKat) and it's ok so far.